### PR TITLE
Fix whitespace control for chained blocks

### DIFF
--- a/lib/whitespace-control.js
+++ b/lib/whitespace-control.js
@@ -55,7 +55,13 @@ WhitespaceControl.prototype.Program = function (program) {
       // Always strip the next node
       omitRight(body, i);
 
-      omitLeft((current.inverse || current.program).body);
+      let lastInverse = current.inverse || current.program;
+      while (lastInverse.chained) {
+        let child = lastInverse.body[lastInverse.body.length - 1]
+        lastInverse = child.inverse || child.program
+      }
+
+      omitLeft(lastInverse.body);
     }
   }
 

--- a/spec/ast.js
+++ b/spec/ast.js
@@ -17,6 +17,11 @@ describe('ast', function () {
         equals(ast.body[0].value, '');
         equals(ast.body[1].program.body[0].value, 'foo');
       });
+
+      it('chained block statements', function () {
+        let ast = parse('{{#if false}}\n{{else if false}}\n{{else}}\n\t{{/if}}');
+        equals(ast.body[0].inverse.body[0].inverse.body[0].value, '');
+      })
     });
 
     describe('parseWithoutProcessing', function () {

--- a/spec/parser.js
+++ b/spec/parser.js
@@ -256,6 +256,10 @@ describe('parser', function () {
       '{{#foo}} bar {{else if bar}}{{else}} baz {{/foo}}',
       "BLOCK:\n  p%foo\n  PROGRAM:\n    CONTENT[ ' bar ' ]\n  {{^}}\n    BLOCK:\n      p%if [p%bar]\n      PROGRAM:\n      {{^}}\n        CONTENT[ ' baz ' ]"
     );
+    equalsAst(
+      '\t{{#if false}}\n\t{{else if false}}\n\t{{else}}\n\t{{/if}}',
+      "CONTENT[ '' ]\nBLOCK:\n  p%if [b%false]\n  PROGRAM:\n    CONTENT[ '' ]\n  {{^}}\n    BLOCK:\n      p%if [b%false]\n      PROGRAM:\n        CONTENT[ '' ]\n      {{^}}\n        CONTENT[ '' ]"
+    );
   });
 
   it('parses empty blocks', function () {


### PR DESCRIPTION
omitLeft failed for helper ending block in chained inverse. It tried to omitLeft whitespace only for the first inverse, which is incorrect. Failing scenario:
```
{{#if false}}
{{else if false}}
{{else}}
	{{/if}}
```
TAB used to make it into the template.
WhitespaceControl failed to omit tab character, while working properly on a bit simpler scenario:
```
{{#if false}}
{{else}}
	{{/if}}
```
Here, TAB did not use to make it into the template.

This PR fixes first scenario to also omit tab.