### PR TITLE
fix: After the the thing builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "license": "ISC",
   "author": "",
-  "type": "module",
   "exports": {
     ".": {
       "require": {


### PR DESCRIPTION
Somewhere between `v2.1.0` and `v2.2.0` this package started having issues with `ember-cli-addon-docs`. This patch fixes that.

Fixes: #20 

With this change I can remove [the override](https://github.com/ember-intl/ember-intl/blob/main/package.json#L33) from `ember-intl`s `pakcage.json`:

```diff
   "pnpm": {
     "overrides": {
-      "ember-cli-addon-docs>@handlebars/parser": "2.1.0"
+      "ember-cli-addon-docs": "file:../ember-cli-addon-docs", // points to `v2.2.0` version of the addon
+      "ember-cli-addon-docs>@handlebars/parser": "file:../handlebars-parser" // points to my fix
     }
   }
```

And `ember-intl` addon docs boot up correctly.