### PR TITLE
fix: Bump node requirement to >=20.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@ Handlebars Parser
 
 The official Handlebars.js parser. This package contains the definition for
 for the Handlebars language AST, and the parser for parsing into that AST.
+
+
+Notes
+-----
+
+If consumers of this package or their dependants get following error message:
+
+```
+require() of ES Module .../.pnpm/@handlebars+parser@file+..+handlebars-parser/node_modules/@handlebars/parser/dist/cjs/index.js not supported.
+Instead change the require of index.js in null to a dynamic import() which is available in all CommonJS modules.
+```
+
+then the solution is to bump [node >= 20.19](https://nodejs.org/en/blog/release/v20.19.0/).

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "packageManager": "pnpm@9.12.2",
   "engines": {
-    "node": "^20.18.0"
+    "node": "^20.19.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
- As per [this issue in ember-cli-addon-docs](https://github.com/ember-learn/ember-cli-addon-docs/issues/1669)
- As per [this Discord discussion](https://discord.com/channels/480462759797063690/484421898210377729/1361741610735370240)

1) _Correct_ solution is quite convoluted
2) Having _some_ documentation to be search-able seems like a good step anyway 3) Requiring `node>=20.19` internally seems like a good step anyway?