### PR TITLE
Fix whitespace handling for chained `{{else if}}` blocks

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -164,8 +164,18 @@ export function prepareBlock(
       );
     }
 
-    if (inverseAndProgram.chain) {
-      inverseAndProgram.program.body[0].closeStrip = close.strip;
+    // Only at the outermost block (where close is the real closing tag, not another
+    // chain link) propagate its strip flags through all chained else-if blocks.
+    if (inverseAndProgram.chain && !close.chain) {
+      const closeStrip = close.strip;
+      let innerBlock = inverseAndProgram.program.body[0];
+      // Walk the full chain so every block gets the real closing tag's strip flags.
+      while (innerBlock) {
+        innerBlock.closeStrip = closeStrip;
+        innerBlock = (innerBlock.inverse && innerBlock.inverse.chained)
+          ? innerBlock.inverse.body[0]
+          : null;
+      }
     }
 
     inverseStrip = inverseAndProgram.strip;

--- a/lib/whitespace-control.js
+++ b/lib/whitespace-control.js
@@ -55,7 +55,21 @@ WhitespaceControl.prototype.Program = function (program) {
       // Always strip the next node
       omitRight(body, i);
 
-      omitLeft((current.inverse || current.program).body);
+      // For chained else-if blocks, walk the chain and strip trailing indent
+      // from every terminal body so all execution paths lose the close-tag indent.
+      let chainNode = current.inverse;
+      if (chainNode && chainNode.chained) {
+        while (chainNode && chainNode.chained) {
+          let lastBlock = chainNode.body[chainNode.body.length - 1];
+          omitLeft(lastBlock.program.body);
+          chainNode = lastBlock.inverse;
+        }
+        if (chainNode) {
+          omitLeft(chainNode.body);
+        }
+      } else {
+        omitLeft((current.inverse || current.program).body);
+      }
     }
   }
 

--- a/spec/ast.js
+++ b/spec/ast.js
@@ -17,6 +17,17 @@ describe('ast', function () {
         equals(ast.body[0].value, '');
         equals(ast.body[1].program.body[0].value, 'foo');
       });
+
+      it('tilde on one else-if does not strip trailing whitespace in later branches', function () {
+        let ast = parse('{{#if a}}A{{else if b}}B {{~else if c}}C {{/if}}'),
+          block = ast.body[0],
+          bBlock = block.inverse.body[0],
+          cBlock = bBlock.inverse.body[0];
+
+        equals(block.program.body[0].value, 'A');
+        equals(bBlock.program.body[0].value, 'B'); // tilde strips trailing space from b
+        equals(cBlock.program.body[0].value, 'C '); // no tilde on {{/if}}, space preserved
+      });
     });
 
     describe('parseWithoutProcessing', function () {

--- a/spec/ast.js
+++ b/spec/ast.js
@@ -236,6 +236,20 @@ describe('ast', function () {
 
         equals(ast.body[2].value, '');
       });
+
+      it('strips close-tag indent from all chained else-if branches', function () {
+        let ast = parse(
+            '  {{#if a}}\n    foo\n  {{else if b}}\n    bar\n  {{else if c}}\n    baz\n  {{/if}}'
+          ),
+          block = ast.body[1],
+          bBlock = block.inverse.body[0],
+          cBlock = bBlock.inverse.body[0];
+
+        equals(ast.body[0].value, '');
+        equals(block.program.body[0].value, '    foo\n');
+        equals(bBlock.program.body[0].value, '    bar\n');
+        equals(cBlock.program.body[0].value, '    baz\n'); // indent before {{/if}} stripped
+      });
     });
     describe('partials - parseWithoutProcessing', function () {
       it('simple partial', function () {


### PR DESCRIPTION
Two related bugs affecting templates that use chained `{{else if}}` branches:

  **1. Standalone close-tag indent not stripped from all chained else-if branches**

  When a block with `{{else if}}` branches was written on its own line (standalone), `omitLeft` only stripped the trailing indent from the first branch's body. Every other execution path kept an extra indent before the closing tag's content. The `Program` handler now walks the full inverse chain so all branches are treated consistently. Resolves handlebars-lang/handlebars.js#1716

  This is also an issue I ran into when developing [PHP Handlebars Parser](https://github.com/devtheorem/php-handlebars-parser), which implements the same whitespace control logic.

  **2. Tilde whitespace control in one branch affecting another**

  `prepareBlock` propagated `closeStrip` one chain level at a time during grammar reduction, so a tilde on `{{~else if}}` leaked into the `closeStrip` of the next block in the chain, causing unintended whitespace stripping in unrelated branches. The fix walks the full chain in the single outer `prepareBlock` call (where `close` is the actual closing tag) and stamps the correct `closeStrip` onto every block, rather than letting each intermediate reduction overwrite it with the wrong strip. Resolves handlebars-lang/handlebars.js#2031

Once this is merged I can open a separate pull request against handlebars.js adding the following test cases to `spec/whitespace-control.js` (which I've already confirmed pass with this branch):

```js
it('GH-1716: should strip trailing indent from chained else if blocks', function () {
	expectTemplate(
	  "{{#if a}}\n {{#if a.b}}\n no\n {{else if a.b}}\n no\n {{else}}\n yes\n {{/if}}\n after\n{{/if}}"
	)
	  .withInput({ a: {c: true} })
	  .toCompileTo(' yes\n after\n');
});

it('GH-2031: whitespace control in one else if branch should not affect another branch', function () {
  var string = "{{#if a}}\na\n{{else if b}}\nb\n{{else if c}}\nc\n{{~else if d}}\nd\n{{else if e}}\ne\n{{else if f}}\nf{{/if}}";
	expectTemplate(string)
	  .withInput({ c: 1 })
	  .toCompileTo("c");

	expectTemplate(string)
	  .withInput({ d: 1 })
	  .toCompileTo("d\n");
	
	expectTemplate(string)
	  .withInput({ e: 1 })
	  .toCompileTo("e\n");
});
```